### PR TITLE
Split functionality into two mixins with better names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A component that intends to initialize child components should mix in `withChild
 
 The child will be passed an even to listen out for – when it's triggered, the child will teardown. `withChildComponents` mixin adds a unique event name to the parent (`this.childTeardownEvent`) for this use, but you can manually specify a `teardownOn` event name in the child's attrs.
 
-This construct supports trees of components because a child's `childTeardownEvent` will be fired before the child is torn down, and that will teardown any of the child's children in a cascade.
+This construct supports trees of components because, if the child also mixes in `withChildComponents`, it's `childTeardownEvent` will be fired before it is torn down, and that will teardown any further children in a cascade.
 
 ## Installation
 
@@ -16,8 +16,7 @@ bower install --save flight-with-child-components
 
 ## Example
 
-In the parent component, mixin `withChildComponents` into the parent and its child
-dependencies.
+In the parent component, mixin `withChildComponents` into the parent.
 
 ```js
 var withChildComponents = require('path/to/the/mixin');
@@ -32,7 +31,8 @@ function parentComponent() {
     // this.attachChild does all the work needed to support nesting
     this.attachChild(ChildComponent, this.select('someChild'));
 
-    this.attachChild(AnotherChildComponent, this.select('anotherChild'), {
+    // it supports the same API as 'attachTo'
+    this.attachChild(AnotherChildComponent, '.another-child', {
       teardownOn: 'someEvent'
     });
   });

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "main": "lib/flight-with-child-components.js",
   "dependencies": {
-    "flight": "~1.1.4"
+    "flight": "v1.2.0"
   },
   "license": "MIT",
   "devDependencies": {

--- a/lib/flight-with-child-components.js
+++ b/lib/flight-with-child-components.js
@@ -8,9 +8,27 @@ define(function () {
 
     var teardownEventCount = 0;
 
-    function withChildComponents() {
-        /* jshint validthis: true */
+    function withBoundLifecycle() {
+        this.attributes({
+            teardownOn: ''
+        });
 
+        /**
+         * If we were given a teardownOn event then listen out for it to teardown.
+         */
+        this.after('initialize', function () {
+            if (this.attr.teardownOn) {
+                if (this.attr.teardownOn === this.childTeardownEvent) {
+                    throw new Error('Component initialized to listen for its own teardown event.');
+                }
+                this.on(document, this.attr.teardownOn, function () {
+                    this.teardown();
+                });
+            }
+        });
+    }
+
+    function withChildComponents() {
         /**
          * Give every component that uses this mixin a new, unique childTeardownEvent
          */
@@ -24,19 +42,7 @@ define(function () {
          * Before this component's teardown, tell all the children to teardown
          */
         this.before('teardown', function () {
-            this.trigger(document, this.childTeardownEvent);
-        });
-
-        /**
-         * If we were given a teardownOn event then listen out for it to teardown.
-         */
-        this.after('initialize', function () {
-            if (this.attr.teardownOn) {
-                if (this.attr.teardownOn === this.childTeardownEvent) {
-                    throw new Error('Component initialized to listen for its own teardown event.');
-                }
-                this.on(document, this.attr.teardownOn, this.teardown);
-            }
+            this.trigger(this.childTeardownEvent);
         });
 
         /**
@@ -50,9 +56,11 @@ define(function () {
             if (!attrs.teardownOn) {
                 attrs.teardownOn = this.childTeardownEvent;
             }
-            Component
-                .mixin(withChildComponents)
-                .attachTo(destination, attrs);
+            var mixins = Component.prototype.mixedIn || [];
+            var isMixedIn = (mixins.indexOf(withBoundLifecycle) > -1) ? true : false;
+            (isMixedIn ?
+                Component :
+                Component.mixin(withBoundLifecycle)).attachTo(destination, attrs);
         };
 
     }
@@ -61,6 +69,9 @@ define(function () {
         teardownEventCount += 1;
         return '_teardownEvent' + teardownEventCount;
     };
+
+    // Export the child lifecycle mixin
+    withChildComponents.withBoundLifecycle = withBoundLifecycle;
 
     return withChildComponents;
 });


### PR DESCRIPTION
- withChildComponents (exported) and withBoundLifecycle (internal)
- Don't mix withBoundLifecycle twice

**Not ready for merge** but here for review and to track progress.

Todo:
- [x] Add test for only mixing into child once
- [x] Test with demo app
- [x] Update docs with Flight 1.2.0 requirement and note about withBoundLifecycle
