### PR TITLE
umd package

### DIFF
--- a/lib/flight-with-child-components.js
+++ b/lib/flight-with-child-components.js
@@ -3,8 +3,23 @@
  *
  * See the README.md for up-to-date docs.
  */
-define(function () {
-    'use strict';
+'use strict';
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], function () {
+      return (root.returnExportsGlobal = factory());
+    });
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like enviroments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    factory();
+  }
+}(this, function () {
 
     var teardownEventCount = 0;
 
@@ -76,4 +91,5 @@ define(function () {
     withChildComponents.withBoundLifecycle = withBoundLifecycle;
 
     return withChildComponents;
-});
+
+}));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "flight-with-child-components",
   "version": "0.2.3",
+  "main": "lib/flight-with-child-components.js",
   "devDependencies": {
     "bower": "^1.3.3",
     "grunt": "~0.4.1",


### PR DESCRIPTION
use UMD to wrap the mixin so it can be used with AMD as well as commonjs-compatible environments.

addresses #12