### PR TITLE
Attach utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const { attach } = require('flight-with-child-components');
 You can use `attach` to attach Flight components like you would with `attachTo`, but you *also* can grab the resulting teardown event from the returned object:
 
 ```js
-const { teardownEvent } = attach(Component, '.some-node', { ... });
+const { teardownEvent } = attach(Component, '.some-node');
 ```
 
 You can then manually tear the component down using a jQuery event.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ You can then manually tear the component down using a jQuery event.
 $(document).trigger(teardownEvent);
 ```
 
+Like with `attachChild`, you can supply a custom `teardownOn` event name:
+
+```js
+const { teardownEvent } = attach(Component, '.some-node', {
+  teardownOn: 'someTeardownEvent'
+});
+```
+
+In this example, `teardownEvent` will be `someTeardownEvent`.
+
 ## Development
 
 To develop this module, clone the repository and run:

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -2,25 +2,11 @@ var webpack = require('webpack');
 
 var DedupePlugin = webpack.optimize.DedupePlugin;
 var OccurenceOrderPlugin = webpack.optimize.OccurenceOrderPlugin;
-var UglifyJsPlugin = webpack.optimize.UglifyJsPlugin;
 
 var plugins = [
     new DedupePlugin(),
     new OccurenceOrderPlugin()
 ];
-
-if (process.env.NODE_ENV === 'publish') {
-    plugins.push(
-        new UglifyJsPlugin({
-            compress: {
-                dead_code: true,
-                drop_console: true,
-                screw_ie8: true,
-                warnings: true
-            }
-        })
-    );
-}
 
 module.exports = {
     entry: './src',

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@
 var teardownEventCount = 0;
 
 /**
- * attacher takes a function that generates an
+ * attacher takes a function that generates event-name strings. The supplied function is
+ * called every time a child component is attached.
  */
 function attacher(eventNameGenerator) {
     if (typeof eventNameGenerator !== 'function') {

--- a/src/with-child-components.spec.js
+++ b/src/with-child-components.spec.js
@@ -116,7 +116,7 @@ describe('withChildComponents', function () {
         it('should return an object with the child teardown event', function () {
             var component = new Component();
             component.initialize(window.outerDiv);
-            const result = component.attachChild(FakeComponent, '.my-selector', { test: true });
+            var result = component.attachChild(FakeComponent, '.my-selector', { test: true });
             expect(result.teardownEvent).toEqual(component.childTeardownEvent);
         });
         it('should mix withBoundLifecycle into child', function () {
@@ -180,14 +180,14 @@ describe('withChildComponents', function () {
             });
         });
         it('should return an object with the supplied teardown event', function () {
-            const result = withChildComponents.attach(FakeComponent, '.my-selector', {
+            var result = withChildComponents.attach(FakeComponent, '.my-selector', {
                 test: true,
                 teardownOn: 'someTeardownEvent'
             });
             expect(result.teardownEvent).toEqual('someTeardownEvent');
         });
         it('should return an object with the generated teardown event', function () {
-            const result = withChildComponents.attach(FakeComponent, '.my-selector', {
+            var result = withChildComponents.attach(FakeComponent, '.my-selector', {
                 test: true
             });
             expect(result.teardownEvent).toEqual('nextTeardownEvent');

--- a/src/with-child-components.spec.js
+++ b/src/with-child-components.spec.js
@@ -113,6 +113,12 @@ describe('withChildComponents', function () {
                 teardownOn: component.childTeardownEvent
             });
         });
+        it('should return an object with the child teardown event', function () {
+            var component = new Component();
+            component.initialize(window.outerDiv);
+            const result = component.attachChild(FakeComponent, '.my-selector', { test: true });
+            expect(result.teardownEvent).toEqual(component.childTeardownEvent);
+        });
         it('should mix withBoundLifecycle into child', function () {
             var component = new Component();
             component.initialize(window.outerDiv);
@@ -142,6 +148,49 @@ describe('withChildComponents', function () {
                 test: true,
                 teardownOn: 'someTeardownEvent'
             });
+        });
+    });
+
+    describe('attach', function () {
+        let _nextTeardownEvent;
+        beforeEach(function () {
+            _nextTeardownEvent = withChildComponents.nextTeardownEvent;
+            withChildComponents.nextTeardownEvent = () => 'nextTeardownEvent';
+        });
+        afterEach(function () {
+            withChildComponents.nextTeardownEvent = _nextTeardownEvent;
+        });
+        it('should allow attaching without a parent', function () {
+            withChildComponents.attach(FakeComponent, '.my-selector', {
+                test: true
+            });
+            expect(FakeComponent.attachTo).toHaveBeenCalledWith('.my-selector', {
+                test: true,
+                teardownOn: 'nextTeardownEvent'
+            });
+        });
+        it('should allow attaching without a parent with a custom teardown event', function () {
+            withChildComponents.attach(FakeComponent, '.my-selector', {
+                test: true,
+                teardownOn: 'someTeardownEvent'
+            });
+            expect(FakeComponent.attachTo).toHaveBeenCalledWith('.my-selector', {
+                test: true,
+                teardownOn: 'someTeardownEvent'
+            });
+        });
+        it('should return an object with the supplied teardown event', function () {
+            const result = withChildComponents.attach(FakeComponent, '.my-selector', {
+                test: true,
+                teardownOn: 'someTeardownEvent'
+            });
+            expect(result.teardownEvent).toEqual('someTeardownEvent');
+        });
+        it('should return an object with the generated teardown event', function () {
+            const result = withChildComponents.attach(FakeComponent, '.my-selector', {
+                test: true
+            });
+            expect(result.teardownEvent).toEqual('nextTeardownEvent');
         });
     });
 });


### PR DESCRIPTION
This utility helps you coordinate Flight-component teardown from non-Flight code.

First, import the `attach` method:

```js
const { attach } = require('flight-with-child-components');
```

You can use `attach` to attach Flight components like you would with `attachTo`, but you *also* can grab the resulting teardown event from the returned object:

```js
const { teardownEvent } = attach(Component, '.some-node', { ... });
```

You can then manually tear the component down using a jQuery event.

```js
$(document).trigger(teardownEvent);
```
